### PR TITLE
Update flash.c

### DIFF
--- a/Target/Source/_template/flash.c
+++ b/Target/Source/_template/flash.c
@@ -626,6 +626,10 @@ static tFlashBlockInfo *FlashSwitchBlock(tFlashBlockInfo *block, blt_addr base_a
       /* invalidate the result value to flag the error */
       result = BLT_NULL;
     }
+    else
+    {
+      result = block;
+    }
   }
 
   /* only continue if all is okay sofar */


### PR DESCRIPTION
When FlashWriteBlock return BLT_TRUE, it should be set 'result' to 'block'. Otherwise, even if a flash block was written successful, fucntion FlashSwitchBlock also return BLT_NULL. This template file should not contain this bug.