### PR TITLE
xcpMaxCto should be of bigger type, otherwise xcpMaxCto > XCPLOADER_P…

### DIFF
--- a/Host/Source/LibOpenBLT/xcploader.c
+++ b/Host/Source/LibOpenBLT/xcploader.c
@@ -122,7 +122,7 @@ static bool xcpConnected;
 static bool xcpSlaveIsIntel;
 
 /** \brief The max number of bytes in the command transmit object (master->slave). */
-static uint8_t xcpMaxCto;
+static uint16_t xcpMaxCto;
 
 /** \brief The max number of bytes in the command transmit object (master->slave) during
  *         a programming session.

--- a/Host/Source/LibOpenBLT/xcploader.c
+++ b/Host/Source/LibOpenBLT/xcploader.c
@@ -127,7 +127,7 @@ static uint16_t xcpMaxCto;
 /** \brief The max number of bytes in the command transmit object (master->slave) during
  *         a programming session.
  */
-static uint8_t xcpMaxProgCto;
+static uint16_t xcpMaxProgCto;
 
 /** \brief The max number of bytes in the data transmit object (slave->master). */
 static uint16_t xcpMaxDto;


### PR DESCRIPTION
…ACKET_SIZE_MAX(255) makes no sense