### PR TITLE
Downgrade cmake requirment to 3.10

### DIFF
--- a/Host/Source/BootCommander/CMakeLists.txt
+++ b/Host/Source/BootCommander/CMakeLists.txt
@@ -25,7 +25,7 @@
 # \endinternal
 #****************************************************************************************
 # Specify the version being used aswell as the language
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 
 
 #****************************************************************************************

--- a/Host/Source/LibOpenBLT/CMakeLists.txt
+++ b/Host/Source/LibOpenBLT/CMakeLists.txt
@@ -25,7 +25,7 @@
 # \endinternal
 #****************************************************************************************
 # Specify the version being used aswell as the language
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 
 
 #****************************************************************************************

--- a/Host/Source/SeedNKey/CMakeLists.txt
+++ b/Host/Source/SeedNKey/CMakeLists.txt
@@ -25,7 +25,7 @@
 # \endinternal
 #****************************************************************************************
 # Specify the version being used aswell as the language
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 
 
 #****************************************************************************************


### PR DESCRIPTION
Looks like no features of 3.15 are used and more relaxed 3.10 seems to work for us on a less latest version of debian