### PR TITLE
Reset bulkUsbDev after close to prevent crash with NULL pointers

### DIFF
--- a/Host/Source/LibOpenBLT/port/windows/usbbulk.c
+++ b/Host/Source/LibOpenBLT/port/windows/usbbulk.c
@@ -320,6 +320,9 @@ static void UblClose(void)
   {
     (void)CloseHandle(bulkUsbDev.hDev);
   }
+  bulkUsbDev.evReader = NULL;
+  bulkUsbDev.hWinUSBDev = NULL;
+  bulkUsbDev.hDev = NULL;
 } /*** end of UblClose ***/
 
 


### PR DESCRIPTION
When using libopenblt with an external tool (like bootcommander), multiple usage of BltSession could bring a crash with outdated pointers not NULL. 
Setting to NULL on UblClose prevent this crash for successive use of UblOpen/Close